### PR TITLE
refactor: use response manager interface instead of concrete class

### DIFF
--- a/packages/mimic-core/src/response_manager.ts
+++ b/packages/mimic-core/src/response_manager.ts
@@ -5,12 +5,18 @@ import { deleteConfig, writeConfig } from "./config";
 import { IUniq, pick, toCallback } from "./utils";
 
 export type IResponses = IUniq<IUniq<any>>;
+
+// Base Response manager for providers
+export interface IBaseResponseManager {
+  find: (id: string) => IUniq<any>;
+  delete: (id: string, callback?: (err: Error | null) => null) => void;
+}
 /**
  * Responses Manager
  *
  * @class ResponseManager
  */
-export class ResponseManager extends EventEmitter {
+export class ResponseManager extends EventEmitter implements IBaseResponseManager {
   constructor(public responses: IResponses = {}) {
     super();
   }

--- a/packages/mimic-graphql/src/provider.ts
+++ b/packages/mimic-graphql/src/provider.ts
@@ -1,6 +1,7 @@
 import {
   deleteConfig,
   detectGit,
+  IBaseResponseManager,
   IGit,
   IMimicRequest,
   IServiceJson,
@@ -9,7 +10,6 @@ import {
   mapValues,
   pick,
   readRecursively,
-  ResponseManager,
   toCallback,
   writeConfig,
 } from "@creditkarma/mimic-core";
@@ -50,7 +50,7 @@ export class GraphQLProvider extends EventEmitter implements IServiceProvider {
   public introSchemas: IUniq<IGraphqlTypes> = {};
 
   // Initialize
-  constructor(private schemas: IUniq<string>, private respManager: ResponseManager) {
+  constructor(private schemas: IUniq<string>, private respManager: IBaseResponseManager) {
     super();
     this.gqlSchemas = mapValues(this.schemas, (s) => {
       const schema = gql.buildSchema(s);

--- a/packages/mimic-rest/src/provider.ts
+++ b/packages/mimic-rest/src/provider.ts
@@ -1,9 +1,11 @@
-import { IMimicRequest, IServiceJson, IServiceProvider, ResponseManager } from "@creditkarma/mimic-core";
+import { IBaseResponseManager, IMimicRequest, IServiceJson, IServiceProvider } from "@creditkarma/mimic-core";
 import { EventEmitter } from "events";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { Server } from "net";
 import { parse } from "url";
 import RouterTree from "./router";
+
+interface IEventedResponseManager extends IBaseResponseManager, EventEmitter {}
 
 /**
  * REST Service Provider
@@ -11,10 +13,8 @@ import RouterTree from "./router";
  * @class RestProvider
  */
 export class RestProvider extends EventEmitter implements IServiceProvider {
-  private respManager: ResponseManager;
-
   // Initialize
-  constructor(respManager: ResponseManager) {
+  constructor(private respManager: IEventedResponseManager) {
     super();
     this.respManager = respManager;
     // Remove responses

--- a/packages/mimic-thrift/src/provider.ts
+++ b/packages/mimic-thrift/src/provider.ts
@@ -19,6 +19,7 @@ import {
 import {
   deleteConfig,
   detectGit,
+  IBaseResponseManager,
   IClient,
   IClientProvider,
   IGit,
@@ -27,7 +28,6 @@ import {
   IServiceProvider,
   IUniq,
   pick,
-  ResponseManager,
   toCallback,
   writeConfig,
 } from "@creditkarma/mimic-core";
@@ -76,13 +76,11 @@ export class ThriftProvider extends EventEmitter implements IServiceProvider, IC
     Json: TJSONProtocol,
     Compact: TCompactProtocol,
   };
-  public thrift: IUniq<ThriftFile.IJSON>;
   public clients: IUniq<IClient> = {};
   private headers: IUniq<any> = {};
-  private respManager: ResponseManager;
 
   // Initialize
-  constructor(thrift: IUniq<ThriftFile.IJSON>, respManager: ResponseManager) {
+  constructor(public thrift: IUniq<ThriftFile.IJSON>, private respManager: IBaseResponseManager) {
     super();
     this.thrift = thrift;
     this.respManager = respManager;


### PR DESCRIPTION
Use response manager interface instead of concrete class

<!--- Provide a general summary of your changes in the Title above -->

## Description
Use ResponseManager interface in providers, instead of concrete class. It allows to replace
ResponseManager with other implementation for test purposes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows to replace ResponseManager with other implementation for test purposes

## How Has This Been Tested?
Compiled project and ran unit-tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (A code change that neither fixes a bug nor adds a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
