### PR TITLE
fix: fix keys with the same name in tree-view

### DIFF
--- a/src/renderer/containers/thrift/Documentation.tsx
+++ b/src/renderer/containers/thrift/Documentation.tsx
@@ -191,7 +191,10 @@ export class Documentation extends React.PureComponent<IProps, IState> {
   public func = (service: string, f: ThriftFile.IFunction, i: number) =>
     <div className="definition" key={i}>
       <h4>Function: {service}.{f.name}</h4>
-      <pre><code>{this.formatType(f.returnTypeId, f.returnType, f.returnExtra)}</code> {f.name}
+      <pre>
+        <code>
+          {f.oneway ? "oneway " : ""}{this.formatType(f.returnTypeId, f.returnType, f.returnExtra)} {f.name}
+        </code>
         ({this.args(f.arguments)}) {f.exceptions.length > 0 ? "throws" : ""} {this.args(f.exceptions)}
       </pre>
       {f.doc ? <pre>{f.doc}</pre> : null}


### PR DESCRIPTION
## Description

Keys with the same name in Tree-view will expand and collapse together, because they are not unique.
Adding a fix to generate unique key for every item in a Tree-view

## Motivation and Context
fix #11

## How Has This Been Tested?
Manual tests and unit-tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
