### PR TITLE
feat: added support for uploading graphql files with .gql extension

### DIFF
--- a/packages/mimic-core/src/utils.ts
+++ b/packages/mimic-core/src/utils.ts
@@ -179,3 +179,6 @@ export const readRecursively = (fsPath: string, ext = "") =>
       resolve({});
     });
   });
+
+export const readMultiExtRecursively = (fsPath: string, exts: Array<string>): Promise<{ [key: string]: string; }[]> =>
+  Promise.all(exts.map((ext) => readRecursively(fsPath, ext)))

--- a/packages/mimic-graphql/src/provider.ts
+++ b/packages/mimic-graphql/src/provider.ts
@@ -9,7 +9,7 @@ import {
   IUniq,
   mapValues,
   pick,
-  readRecursively,
+  readMultiExtRecursively,
   toCallback,
   writeConfig,
 } from "@creditkarma/mimic-core";
@@ -139,8 +139,16 @@ export class GraphQLProvider extends EventEmitter implements IServiceProvider {
    * Read GraphQL files recursively
    */
   public readGraphQL = (files: string[], callback: (err: Error | null, files?: {[key: string]: string}) => void) =>
-    Promise.all(files.map((f) => readRecursively(f, "graphql"))).then((values) => {
-      const content = Object.assign({}, ...values);
+    Promise.all(files.map((f) => readMultiExtRecursively(f, ["graphql", "gql"]))).then((nestedValues) => {
+      let content = {};
+      nestedValues.forEach(values => {
+        values.forEach(value => {
+          content = {
+            ...content,
+            ...value
+          };
+        });
+      })
       callback(null, content);
     }, (err) => callback(err))
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -98,7 +98,7 @@ export class App {
     dialog.showOpenDialog({
       properties: ["openFile", "openDirectory", "multiSelections"],
       filters: [
-        { name: "GraphQL Files", extensions: ["graphql"] },
+        { name: "GraphQL Files", extensions: ["graphql", "gql"] },
       ],
     }, (files) => {
       if (files) {


### PR DESCRIPTION
Added support for creating GraphQL services with .gql files.

## Description

Users can now create GraphQL services with .gql files. This is in addition to the prior support, which only allowed for .graphql files.

## Motivation and Context

Some people use .graphql, and others use .gql. We should support both file extensions so there isn't friction for the user who uses .gql.

## How Has This Been Tested?

Manual testing.

1.a Create a service with .graphql file
2.b Use service in Mimic
2.c Delete service

2.a Create a service with .gql file
2.b Use service in Mimic
3.c Delete service

Both workflows worked.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
